### PR TITLE
add : 주문 요청 API 추가 (+ update: schema.prisma)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -56,7 +56,7 @@ model Stores {
 }
 
 model Menus {
-  menuId    Int    @id @default(autoincrement()) @map("userId")
+  menuId    Int    @id @default(autoincrement()) @map("menuId")
   storeId   Int    @map("storeId")
   menuName  String @map("menuName")
   menuImage String @map("menuImage")
@@ -104,7 +104,7 @@ model OrderItems {
   menuId    Int      @map("menuId")
   menuName  String   @map("menuName")
   price     Int      @map("price")
-  createdAt DateTime @default(now()) @map("createdAt")
+  quantity  Int      @map("quantity")
 
   orders Orders @relation(fields: [orderId], references: [orderId], onDelete: Cascade)
 }

--- a/src/controllers/orders.controller.js
+++ b/src/controllers/orders.controller.js
@@ -5,14 +5,14 @@ export default class OrdersController {
 
   order = async (req, res, next) => {
     try {
-      const { storeId, menus } = req.body;
-    //   console.log(storeId, menus);
+      // 로그인 기능 merge하면 수정 예정정
+      const { userId, storeId, menus } = req.body;
 
       if(!storeId || !menus)
         return res.status(400).json({message: '주문 정보가 올바르지 않습니다,'});
 
-      const order = await this.ordersService.order(storeId, menus);
-      return res.status(201).json({ message: '주문 완료' });
+      const order = await this.ordersService.order(userId, storeId, menus);
+      return res.status(201).json({ data: order });
     } catch (err) {
       next(err);
     }

--- a/src/repositories/orders.repository.js
+++ b/src/repositories/orders.repository.js
@@ -1,18 +1,61 @@
 export default class OrdersRepository {
-    constructor(prisma) {
-        this.prisma = prisma;
+  constructor(prisma) {
+    this.prisma = prisma;
+  }
+
+  order = async (userId, storeId, menus) => {
+    const menuInfo = [];
+    let totalPrice = 0;
+
+    for (let i = 0; i < menus.length; i++) {
+      const menu = await this.prisma.menus.findFirst({
+        where: {
+          AND: [{ storeId: +storeId }, { menuId: +menus[i].menu }],
+        },
+        select: {
+          menuId: true,
+          menuName: true,
+          price: true,
+        },
+      });
+
+      if (!menu) throw new Error(`menuId : ${menus[i]} 인 메뉴가 없습니다.`);
+
+      menuInfo.push({ menu: menu, quantity: menus[i].quantity });
     }
 
-    order = async (userId, storeId, menus) => {
+    let order;
 
-        const [order, orderItem] = await this.prisma.$transction( async (tx) => {
-            const order = await tx.orders.create({
-                data: {
-                    storeId: +storeId,
-                    userId: +userId,
-                }
-            })
-        })
+    await this.prisma.$transaction(async (tx) => {
+      order = await tx.orders.create({
+        data: {
+          storeId: +storeId,
+          userId: +userId,
+          totalPrice: 0,
+        },
+      });
 
-    }
+      for (let i = 0; i < menuInfo.length; i++) {
+        const item = await tx.orderItems.create({
+          data: {
+            orderId: order.orderId,
+            menuId: menuInfo[i].menu.menuId,
+            menuName: menuInfo[i].menu.menuName,
+            price: menuInfo[i].menu.price,
+            quantity: menuInfo[i].quantity,
+          },
+        });
+        totalPrice += item.price * item.quantity;
+      }
+
+      order = await tx.orders.update({
+        where: { orderId: order.orderId },
+        data: {
+          totalPrice: totalPrice,
+        },
+      });
+    });
+
+    return order;
+  };
 }

--- a/src/services/orders.service.js
+++ b/src/services/orders.service.js
@@ -3,8 +3,8 @@ export default class OrdersService {
         this.ordersRepository = ordersRepository;
     }
 
-    order = async (storeId, menus) => {
-        order = await this.ordersRepository(storeId, menus);
+    order = async (userId, storeId, menus) => {
+        const order = await this.ordersRepository.order(userId, storeId, menus);
 
         return order;
     }


### PR DESCRIPTION
사용자가 주문을 요청하면 orders 테이블에 주문 정보가, orderItems에는 메뉴 정보가 담기도록 동작.

+ schema 구조 변경. orders와 orderItems는 트랜잭션으로 동작하기에 orderItems의 createdAt 삭제(orderItems에 데이터가 많이 담기므로 연속적으로 만들어지는 createdAt은 낭비라고 판단)
orderItems에 수량 quantity 컬럼 추가 (같은 메뉴를 여러개 주문 할 경우 같은 내용의 데이터를 여러번 추가하는 것은 낭비라 생각하여 수량 컬럼을 추가하였음)